### PR TITLE
IE11 compatibility

### DIFF
--- a/hotModuleReplacement.js
+++ b/hotModuleReplacement.js
@@ -1,9 +1,14 @@
 var getCurrentScriptUrl = function() {
   var src;
-  if (document && document.currentScript) {
-    src = document.currentScript.src;
+  if (document) {
+    if (document.currentScript) {
+      src = document.currentScript.src;
+    } else {
+      var scripts = document.getElementsByTagName('script');
+      src = scripts[scripts.length - 1].src;
+    }
   }
-  return () => {
+  return function() {
     return src.replace('.js', '.css');
   };
 }
@@ -13,19 +18,21 @@ var getScriptSrc = getCurrentScriptUrl();
 function getLinkElement() {
   var element;
   var src = getScriptSrc();
-  document.querySelectorAll('link').forEach(el => {
+  var elements = document.querySelectorAll('link');
+  for (var i = 0, el = null; el = elements[i]; i++) {
     if (el.href.indexOf(src) > -1) {
       element = el;
     }
-  });
+  }
   return element;
 }
 
 function reloadAll() {
-  document.querySelectorAll('link').forEach(el => {
+  var elements = document.querySelectorAll('link');
+  for (var i = 0, el = null; el = elements[i]; i++) {
     const src = el.href.split('?')[0];
     el.href = src + '?' + Date.now();
-  });
+  }
 }
 
 module.exports = function() {


### PR DESCRIPTION
Arrow functions, .forEach and document.currentScript aren't supported in IE < Edge.
I replaced the arrow functions with regular functions, added an alternative for .forEach and provided a fallback for document.currentScript.
Works in IE11 for me. Haven't tested in IE versions below ..