### PR TITLE
add missing slashes on hotModuleReplacement path

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,4 +1,5 @@
 const loaderUtils = require('loader-utils');
+const slash = require('slash');
 const defaultOptions = {
   fileMap: '{fileName}',
 };
@@ -13,7 +14,7 @@ module.exports = function(content) {
   return content + `
     if(module.hot) {
       // ${Date.now()}
-      const cssReload = require('${require.resolve('./hotModuleReplacement')}')(${JSON.stringify(options)});
+      const cssReload = require('${slash(require.resolve('./hotModuleReplacement'))}')(${JSON.stringify(options)});
       module.hot.dispose(cssReload);
       module.hot.accept(undefined, cssReload);
     }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "loader-utils": "^1.1.0",
-    "normalize-url": "^1.9.1"
+    "normalize-url": "^1.9.1",
+    "slash": "^1.0.0"
   }
 }


### PR DESCRIPTION
Hi there!
There is a problem happening when running this loader on Windows. The slashes on hotModuleReplacement path are missing. I have fixed this issue by using the slash function added as a dependency.

[]`s