### PR TITLE
Use loaderUtils.stringifyRequest

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -13,7 +13,7 @@ module.exports = function(content) {
   return content + `
     if(module.hot) {
       // ${Date.now()}
-      const cssReload = require('${require.resolve('./hotModuleReplacement')}')(${JSON.stringify(options)});
+      const cssReload = require(${loaderUtils.stringifyRequest(this, require.resolve('./hotModuleReplacement'))})(${JSON.stringify(options)});
       module.hot.dispose(cssReload);
       module.hot.accept(undefined, cssReload);
     }


### PR DESCRIPTION
Absolute path returned by `require.resolve` does not seem to be working in my windows environment. I propose wrapping it with `loaderUtils.stringifyRequest` - recommended way of dealing with absolute urls in webpack
> Since webpack calculates the hash before module paths are translated into module ids, we must avoid absolute paths to ensure consistent hashes across different compilations.
https://github.com/webpack/loader-utils#stringifyrequest