### PR TITLE
Do not strip www from url

### DIFF
--- a/hotModuleReplacement.js
+++ b/hotModuleReplacement.js
@@ -19,7 +19,7 @@ var getCurrentScriptUrl = function() {
     }
     return fileMap.split(',').map(function(mapRule) {
       var reg = new RegExp(filename + '\\.js$', 'g')
-      return normalizeUrl(src.replace(reg, mapRule.replace(/{fileName}/g, filename) + '.css'));
+      return normalizeUrl(src.replace(reg, mapRule.replace(/{fileName}/g, filename) + '.css'), { stripWWW: false });
     });
   };
 }
@@ -52,7 +52,7 @@ function reloadStyle(src) {
 }
 
 function getReloadUrl(href, src) {
-  href = normalizeUrl(href);
+  href = normalizeUrl(href, { stripWWW: false });
   var ret;
   src.some(function(url) {
     if (href.indexOf(src) > -1) {


### PR DESCRIPTION
When using a domain for local development, the 'www.' prefix is stripped from the url and it breaks the injection.

To avoid this, I added the stripWWW option to the normalizeUrl function.