### PR TITLE
Use var instead of const for IE10

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -13,7 +13,7 @@ module.exports = function(content) {
   return content + `
     if(module.hot) {
       // ${Date.now()}
-      const cssReload = require(${loaderUtils.stringifyRequest(this, require.resolve('./hotModuleReplacement'))})(module.id, ${JSON.stringify(options)});
+      var cssReload = require(${loaderUtils.stringifyRequest(this, require.resolve('./hotModuleReplacement'))})(module.id, ${JSON.stringify(options)});
       module.hot.dispose(cssReload);
       module.hot.accept(undefined, cssReload);
     }


### PR DESCRIPTION
Using `const` in css-hot-loader content does not work in IE10, replacing it with var