### PR TITLE
memory leak fix, only reload css files

### DIFF
--- a/hotModuleReplacement.js
+++ b/hotModuleReplacement.js
@@ -27,11 +27,16 @@ var getCurrentScriptUrl = function(moduleId) {
 }
 
 function updateCss(el, url) {
+  if (!el.href || !el.href.endsWith('css')) return;
+
   var newEl = el.cloneNode();
   if (!url) {
     url = el.href.split('?')[0];
   }
   newEl.addEventListener('load', function () {
+    el.remove();
+  });
+  newEl.addEventListener('error', function () {
     el.remove();
   });
   newEl.href = url + '?' + Date.now();
@@ -41,8 +46,8 @@ function updateCss(el, url) {
 function reloadStyle(src) {
   var elements = document.querySelectorAll('link');
   var loaded = false;
-  for (var i = 0, el = null; el = elements[i]; i++) {
-    var url = getReloadUrl(el.href, src);
+  for (let i = 0, el = null; el = elements[i]; i++) {
+    let url = getReloadUrl(el.href, src);
     if (url) {
       updateCss(el, url);
       loaded = true;
@@ -64,7 +69,7 @@ function getReloadUrl(href, src) {
 
 function reloadAll() {
   var elements = document.querySelectorAll('link');
-  for (var i = 0, el = null; el = elements[i]; i++) {
+  for (let i = 0, el = null; el = elements[i]; i++) {
     updateCss(el);
   }
 }

--- a/hotModuleReplacement.js
+++ b/hotModuleReplacement.js
@@ -27,12 +27,13 @@ var getCurrentScriptUrl = function(moduleId) {
 }
 
 function updateCss(el, url) {
-  if (!el.href || !el.href.endsWith('css')) return;
-
-  var newEl = el.cloneNode();
   if (!url) {
     url = el.href.split('?')[0];
   }
+
+  if (!url || !url.endsWith('.css')) return;
+
+  var newEl = el.cloneNode();
   newEl.addEventListener('load', function () {
     el.remove();
   });


### PR DESCRIPTION
There are two issues I noticed while using this loader:

1) The reference to `el` is not bound correctly when calling `updateCss`

For example I think it suffers from this kind of issue:
```javascript
function something(i) { console.log(i); }
for (var i = 0; i < 10; i++) {
  setTimeout(function() { something(i); }, 0)
}
```
Will print `10` 10 times. If you replace `var` with `let` this works the way you would expect. That means that this method will leak orphaned `link` elements on the page and not remove them correctly.

2) Sometimes `el` will not receive the `load` event, again orphaning `link` elements.

I added an additional listener for `error` and made sure that the element is actually a `css` link. For example, this element would be duplicated on the page:

```html
<link rel=icon type=image/png href=/img/favicon/favicon_32.png sizes=32x32>
```