### PR TITLE
replace css link instead of adding new one

### DIFF
--- a/hotModuleReplacement.js
+++ b/hotModuleReplacement.js
@@ -41,7 +41,7 @@ function updateCss(el, url) {
     el.remove();
   });
   newEl.href = url + '?' + Date.now();
-  el.parentNode.insertBefore(newEl, el.nextSibling);
+  el.parentNode.replaceChild(newEl, el)
 }
 
 function reloadStyle(src) {


### PR DESCRIPTION
Hi,

this PR fixes unintentional addition of multiple css links in html head. 