### PR TITLE
replace replaceChild to appendChild

### DIFF
--- a/hotModuleReplacement.js
+++ b/hotModuleReplacement.js
@@ -41,7 +41,7 @@ function updateCss(el, url) {
     el.remove();
   });
   newEl.href = url + '?' + Date.now();
-  el.parentNode.replaceChild(newEl, el)
+  el.parentNode.appendChild(newEl);
 }
 
 function reloadStyle(src) {


### PR DESCRIPTION
如果使用replaceChild,原来的css会直接被替换掉。
这段代码就没意义了。因为css已经被删掉了
```
  newEl.addEventListener('load', function () {
    el.remove();
  });
  newEl.addEventListener('error', function () {
    el.remove();
  });
```
而且在css文件毕竟大的情况下。会导致页面闪屏。
使用appendChild，可以同时保留2个css文件，在新的css加载完，触发load，删除原来的css文件。可以确保不会闪屏
