### PR TITLE
Safe access to 'src' of the last "script" tag

### DIFF
--- a/hotModuleReplacement.js
+++ b/hotModuleReplacement.js
@@ -14,7 +14,11 @@ var getCurrentScriptUrl = function(moduleId) {
       src = document.currentScript.src;
     } else {
       var scripts = document.getElementsByTagName('script');
-      src = scripts[scripts.length - 1].src;
+      var lastScriptTag = scripts[scripts.length - 1];
+
+      if (lastScriptTag) {
+        src = scripts[scripts.length - 1].src;
+      }
     }
     srcByModuleId[moduleId] = src;
   }


### PR DESCRIPTION
There is an error in dev-tools on first page load.
```js
Cannot read property 'src' of undefined
    at getCurrentScriptUrl (hotModuleReplacement.js:17)
    at webpackJsonp.../node_modules/css-hot-loader/hotModuleReplacement.js.module.exports (hotModuleReplacement.js:93)
```

`webpack-dev-server` triggers rebuild right after first bundle without any changes in sources. This issue with `webpack-dev-server` is covered many times, most detailed is webpack/watchpack#25.
Full load of heavy-weighted SPA (even in development environment) doesn't finish before rebuild, `module.hot.dispose` is called, error is thrown.

This PR works around webpack/watchpack#25 for `css-hot-loader`.