### PR TITLE
Update `homepage` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "hotModuleReplacement.js",
     "index.js"
   ],
-  "homepage": "http://git.shepherdwind.com/css-hot-loader/",
+  "homepage": "https://github.com/shepherdwind/css-hot-loader",
   "repository": {
     "type": "git",
     "url": "git://github.com/shepherdwind/css-hot-loader.git"


### PR DESCRIPTION
This is useful when upgrading dependencies... the old link points to a 404 page.