### PR TITLE
replace appendChild by insertBefore

### DIFF
--- a/__tests__/hotModuleReplacement-test.js
+++ b/__tests__/hotModuleReplacement-test.js
@@ -26,7 +26,7 @@ test('basic reload', () => {
   cb();
 
   expect(document.querySelectorAll('link').length === 2).toBe(true);
-  expect(document.querySelectorAll('link')[1].href.indexOf('?') > -1).toBe(true);
+  expect(document.querySelectorAll('link')[0].href.indexOf('?') > -1).toBe(true);
 
   spy.mockReset();
   spy.mockRestore();
@@ -55,9 +55,9 @@ test('reload mult style', () => {
   cb.forEach(fn => fn());
 
   expect(document.querySelectorAll('link').length === 3).toBeTruthy();
-  expect(document.querySelectorAll('link')[0].href.indexOf('?') === -1).toBe(true);
+  expect(document.querySelectorAll('link')[0].href.indexOf('?') > -1).toBe(true);
   expect(document.querySelectorAll('link')[1].href.indexOf('?') > -1).toBe(true);
-  expect(document.querySelectorAll('link')[2].href.indexOf('?') > -1).toBe(true);
+  expect(document.querySelectorAll('link')[2].href.indexOf('?') === -1).toBe(true);
 
   spy.mockReset();
   spy.mockRestore();

--- a/hotModuleReplacement.js
+++ b/hotModuleReplacement.js
@@ -62,7 +62,8 @@ function updateCss(el, url) {
   });
 
   newEl.href = url + '?' + Date.now();
-  el.parentNode.appendChild(newEl);
+  // insert new <link /> right to the old one's position
+  el.parentNode.insertBefore(newEl, el.nextSibling);
 }
 
 function reloadStyle(src) {


### PR DESCRIPTION
之前在 #25 这个 issue 里面，把 `replaceChild` 改成 `appendChild` 是有道理的， 但是 `appendChild` 也会有新的问题，如果 `<head>` 中有多个通过 `<link />` 标签引入的 css 文件，那他们之间的顺序就是权重，所以如果是 `appendChild` 的方式，hot reload 之后会更改 css 文件的引入顺序，新的 reload 进来的 css 永远会在后面，从而影响 css 的权重。

所以，原来那个 css 在哪儿，hot reload 之后应该还是在哪儿。这样多个 css 文件之间的顺序不会被打乱。